### PR TITLE
feat: add collapsible categorized tag toolbar

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,3 +1,22 @@
 import App from './src/App.js';
+import { loadAppData } from './modules/api.js';
+import { setTagTooltips, setTagTaunts, setTaunts } from './modules/tags.js';
+import { setAllArtists as setGalleryArtists, filterArtists } from './modules/gallery.js';
+import { setAllArtists as setExplorerArtists } from './modules/tag-explorer.js';
+import { setAllArtists as setSidebarArtists } from './modules/sidebar.js';
 const { createApp } = Vue;
-createApp(App).mount('#app');
+
+loadAppData()
+  .then(({ artists, tooltips, generalTaunts, tagTaunts }) => {
+    setGalleryArtists(artists);
+    setExplorerArtists(artists);
+    setSidebarArtists(artists);
+    setTagTooltips(tooltips);
+    setTagTaunts(tagTaunts);
+    setTaunts(generalTaunts);
+    createApp(App).mount('#app');
+    filterArtists();
+  })
+  .catch(() => {
+    createApp(App).mount('#app');
+  });

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -3,7 +3,6 @@ import {
   forceSortAndRender,
   setSortPreference,
 } from '../../modules/gallery.js';
-import { openTagExplorer } from '../../modules/tag-explorer.js';
 
 export default {
   name: 'Header',
@@ -28,15 +27,10 @@ export default {
       setSortPreference(sortPreference.value);
     }
 
-    function toggleFilters() {
-      openTagExplorer();
-    }
-
     return {
       sortPreference,
       handleSort,
       updatePreference,
-      toggleFilters,
     };
   },
   template: `
@@ -47,13 +41,12 @@ export default {
           <div class="brand-sissy">✧ Welcome cutie. ✧<br>Obey, drool, and discover your next obsession~</div>
           <span class="tagline" id="tagline">Pathetic..~</span>
           <div class="sort-controls">
-            <select id="sort-preference" v-model="sortPreference" @change="updatePreference">
+            <select id="sort-preference" class="fem-select" v-model="sortPreference" @change="updatePreference">
               <option value="name">Sort: Name (A-Z)</option>
               <option value="count">Sort: Tag Count</option>
               <option value="top">Top Artists (by tag count)</option>
             </select>
-            <button id="sort-button" @click="handleSort">Sort</button>
-            <button id="toggle-filters" type="button" class="browse-btn" aria-expanded="false" @click="toggleFilters">Browse Tags</button>
+            <button id="sort-button" class="fem-btn" @click="handleSort">Sort</button>
             <!-- Only one Top Artists button, handled by JS -->
           </div>
           <div class="top-actions"></div>

--- a/src/components/TagFilter.js
+++ b/src/components/TagFilter.js
@@ -9,6 +9,7 @@ import {
   clearAllTags,
   tagSearchMode,
 } from "../../modules/tags.js";
+import { getFilteredCounts } from "../../modules/tag-explorer.js";
 
 const { ref, computed } = Vue;
 
@@ -28,6 +29,95 @@ const tagIcons = {
   pregnant: "icons/pregnant.png",
 };
 
+// Hand-picked tag categories
+const tagCategories = {
+  Bondage: [
+    "bdsm",
+    "bondage",
+    "shibari",
+    "restraints",
+    "restrained",
+    "hogtie",
+    "leash",
+    "spreader_bar",
+    "chastity_cage",
+    "chastity_cage_emission",
+    "flat_chastity_cage",
+    "holding_key",
+    "immobilization",
+  ],
+  Feminization: [
+    "feminization",
+    "forced_feminization",
+    "bimbofication",
+    "crossdressing",
+    "crossdressing_(mtf)",
+    "trap",
+  ],
+  Penetration: [
+    "anal_fingering",
+    "anal_fisting",
+    "anal_object_insertion",
+    "object_insertion",
+    "object_insertion_from_behind",
+    "urethral_insertion",
+    "prostate_milking",
+    "pegging",
+    "male_penetrated",
+    "dildo_riding",
+    "strap-on",
+    "large_insertion",
+    "huge_dildo",
+    "sounding",
+    "knotting",
+    "tentacle_sex",
+    "tentacle_pit",
+  ],
+  Oral: [
+    "oral",
+    "fellatio",
+    "irrumatio",
+    "cum_in_mouth",
+    "gokkun",
+    "swallowing",
+    "drinking_from_condom",
+    "pouring_from_condom",
+    "precum",
+    "cum",
+    "cumdump",
+    "pussy_juice",
+    "ejaculating_while_penetrated",
+    "handsfree_ejaculation",
+    "penis_milking",
+    "hand_milking",
+    "milking_machine",
+    "lactation",
+  ],
+  Control: [
+    "hypnosis",
+    "mind_break",
+    "mind_control",
+    "orgasm_denial",
+    "dominatrix",
+    "assertive_female",
+    "sadism",
+    "pet_play",
+    "sex_machine",
+  ],
+  Humiliation: [
+    "humiliation",
+    "small_penis",
+    "small_penis_humiliation",
+    "public_nudity",
+    "body_writing",
+    "assisted_exposure",
+    "bullying",
+    "annoyed",
+    "cheating_(relationship)",
+  ],
+  Feet: ["foot_worship", "sockjob", "toe_sucking"],
+};
+
 export default {
   name: "TagFilter",
   props: {
@@ -38,6 +128,26 @@ export default {
   },
   setup(props) {
     const bubbles = ref([]);
+    const collapsed = ref(true);
+    const selectedCategory = ref("All");
+
+    const tagToCategory = computed(() => {
+      const mapping = {};
+      Object.entries(tagCategories).forEach(([cat, tags]) => {
+        tags.forEach((t) => (mapping[t] = cat));
+      });
+      props.tags.forEach((t) => {
+        if (!mapping[t]) mapping[t] = "Other";
+      });
+      return mapping;
+    });
+
+    const categories = computed(() => [
+      "All",
+      ...new Set(Object.values(tagToCategory.value)),
+    ]);
+
+    const tagCounts = computed(() => getFilteredCounts(activeTags.value));
 
     function spawnBubble(tag) {
       const pool = tagTaunts[tag] || taunts;
@@ -59,8 +169,17 @@ export default {
 
     const filteredTags = computed(() => {
       const filter = searchFilter.value.trim().toLowerCase();
+      const counts = tagCounts.value;
+      const mapping = tagToCategory.value;
       return props.tags
         .filter((tag) => {
+          const cat = mapping[tag] || "Other";
+          if (
+            selectedCategory.value !== "All" &&
+            cat !== selectedCategory.value
+          )
+            return false;
+          if (!counts[tag] && !activeTags.value.has(tag)) return false;
           if (!filter) return true;
           const t = tag.toLowerCase();
           if (tagSearchMode === "starts") return t.startsWith(filter);
@@ -71,6 +190,10 @@ export default {
     });
 
     const showClear = computed(() => activeTags.value.size > 0);
+
+    function toggleCollapse() {
+      collapsed.value = !collapsed.value;
+    }
 
     return {
       activeTags,
@@ -83,31 +206,44 @@ export default {
       tagIcons,
       bubbles,
       showClear,
+      categories,
+      selectedCategory,
+      collapsed,
+      toggleCollapse,
     };
   },
   template: `
-    <nav class="filter-bar" role="navigation" aria-label="Tag filters">
-      <div id="tag-filter">
-        <div class="filter-inputs">
-          <label for="tag-search" class="visually-hidden">Filter tags</label>
-          <input
-            type="text"
-            id="tag-search"
-            placeholder="Type to filter tags..."
-            v-model="searchFilter"
-            aria-describedby="tag-search-help"
-          />
+    <nav class="filter-bar" :class="{ collapsed }" role="navigation" aria-label="Tag filters">
+      <div class="filter-inputs">
+        <label for="tag-search" class="visually-hidden">Filter tags</label>
+        <input
+          type="text"
+          id="tag-search"
+          placeholder="Type to filter tags..."
+          v-model="searchFilter"
+          aria-describedby="tag-search-help"
+        />
 
-          <label for="artist-name-filter" class="visually-hidden">Filter by artist name</label>
-          <input
-            type="text"
-            id="artist-name-filter"
-            placeholder="Filter by artist name..."
-            v-model="artistNameFilter"
-            aria-describedby="artist-filter-help"
-          />
-        </div>
+        <label for="artist-name-filter" class="visually-hidden">Filter by artist name</label>
+        <input
+          type="text"
+          id="artist-name-filter"
+          placeholder="Filter by artist name..."
+          v-model="artistNameFilter"
+          aria-describedby="artist-filter-help"
+        />
 
+        <label for="category-select" class="visually-hidden">Tag category</label>
+        <select id="category-select" class="fem-select" v-model="selectedCategory">
+          <option v-for="cat in categories" :key="cat" :value="cat">{{ cat }}</option>
+        </select>
+
+        <button class="filter-toggle" @click="toggleCollapse" :aria-expanded="!collapsed">
+          {{ collapsed ? 'Show Tags' : 'Hide Tags' }}
+        </button>
+      </div>
+
+      <div id="tag-filter" v-show="!collapsed">
         <div id="tag-buttons" role="group" aria-label="Available tags">
           <button
             v-for="tag in filteredTags"

--- a/style.css
+++ b/style.css
@@ -41,29 +41,6 @@ body > nav,
   box-shadow: 0 6px 24px rgba(253, 123, 197, 0.18);
 }
 
-.top-bar {
-  animation: topBarGradient 8s ease-in-out infinite alternate;
-  width: 340px;
-  background: #fff;
-  box-shadow: -2px 0 16px rgba(253, 123, 197, 0.10);
-  border-radius: 12px 0 0 12px;
-  overflow-y: auto;
-  display: none;
-  padding: 1.2em 1em 1em 1em;
-  font-family: 'Inter', sans-serif;
-  font-size: 1rem;
-}
-
-
-@keyframes topBarGradient {
-  0% {
-    background: linear-gradient(120deg, #fff0fa 60%, #ffd6f6 100%);
-  }
-  100% {
-    background: linear-gradient(120deg, #ffd6f6 0%, #fff0fa 100%);
-  }
-}
-
 @keyframes floatingPop {
   0% {
     transform: scale(0.7) translateY(32px);
@@ -129,6 +106,21 @@ body > nav,
 .fem-btn:focus-visible, .browse-btn:focus-visible, .tag-btn:focus-visible, .tag-button:focus-visible, .copy-button:focus-visible, .reload-button:focus-visible, .zoom-tool:focus-visible {
   outline: 3px solid #fd7bc5;
   outline-offset: 2px;
+}
+
+.fem-select {
+  background: linear-gradient(90deg, #fff0fa 0%, #ffd6f6 100%);
+  border: 2px solid var(--border-color);
+  border-radius: var(--radius);
+  padding: 0.4em 0.6em;
+  color: var(--accent2);
+  font-family: var(--btn-font);
+  font-size: 1em;
+}
+
+.browse-btn {
+  background-color: var(--accent1);
+  color: #fff;
 }
 
 /* Utility: sidebar-hidden helper */
@@ -766,6 +758,14 @@ body > nav,
 }
 
 /* Filter UI */
+.filter-bar {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background: rgba(255, 240, 250, 0.95);
+  box-shadow: 0 2px 8px rgba(253, 123, 197, 0.15);
+}
+
 .filter-toggle {
   background: var(--accent1);
   border: none;
@@ -779,7 +779,7 @@ body > nav,
   padding: var(--padding);
 }
 
-.filter-bar.collapsed {
+.filter-bar.collapsed #tag-filter {
   display: none;
 }
 
@@ -1087,16 +1087,6 @@ button[aria-label*="Back"]::after,
 }
 
 /* Keyframes */
-@keyframes topBarGradient {
-  0% {
-    background: linear-gradient(120deg, #fff0fa 60%, #ffd6f6 100%);
-  }
-
-  100% {
-    background: linear-gradient(120deg, #ffd6f6 0%, #fff0fa 100%);
-  }
-}
-
 @keyframes floatingPop {
   0% {
     transform: scale(0.7) translateY(32px);
@@ -1701,7 +1691,3 @@ html.tag-explorer-open {
   font-style: italic;
 }
 
-.browse-btn {
-  background-color: var(--accent1);
-  color: #fff;
-}

--- a/vue/components/Header.js
+++ b/vue/components/Header.js
@@ -3,7 +3,6 @@ import {
   forceSortAndRender,
   setSortPreference,
 } from '../../modules/gallery.js';
-import { openTagExplorer } from '../../modules/tag-explorer.js';
 
 export default {
   name: 'Header',
@@ -28,15 +27,10 @@ export default {
       setSortPreference(sortPreference.value);
     }
 
-    function toggleFilters() {
-      openTagExplorer();
-    }
-
     return {
       sortPreference,
       handleSort,
       updatePreference,
-      toggleFilters,
     };
   },
   template: `
@@ -47,13 +41,12 @@ export default {
           <div class="brand-sissy">✧ Welcome cutie. ✧<br>Obey, drool, and discover your next obsession~</div>
           <span class="tagline" id="tagline">Pathetic..~</span>
           <div class="sort-controls">
-            <select id="sort-preference" v-model="sortPreference" @change="updatePreference">
+            <select id="sort-preference" class="fem-select" v-model="sortPreference" @change="updatePreference">
               <option value="name">Sort: Name (A-Z)</option>
               <option value="count">Sort: Tag Count</option>
               <option value="top">Top Artists (by tag count)</option>
             </select>
-            <button id="sort-button" @click="handleSort">Sort</button>
-            <button id="toggle-filters" type="button" class="browse-btn" aria-expanded="false" @click="toggleFilters">Browse Tags</button>
+            <button id="sort-button" class="fem-btn" @click="handleSort">Sort</button>
             <!-- Only one Top Artists button, handled by JS -->
           </div>
           <div class="top-actions"></div>


### PR DESCRIPTION
## Summary
- add hand-picked tag categories and collapsible toolbar
- load app data before mounting to render artist gallery
- style filter bar as sticky top row with sissy colors
- polish header layout and remove obsolete Browse Tags button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4381b9928832ca21d6c0e0c2bfc1c